### PR TITLE
getDataAsVector() works on osx

### DIFF
--- a/src/Datagram.h
+++ b/src/Datagram.h
@@ -86,7 +86,13 @@ namespace ofxAsio {
 		}
 
 		std::vector<unsigned char> getDataAsVector() {
-			return std::vector<unsigned char>(reinterpret_cast<unsigned char>(mData.data()), mData.size());
+			std::vector<unsigned char> dataVector;
+			dataVector.reserve(mData.size());
+			for (auto c : mData)
+			{
+				dataVector.push_back((unsigned char)c);
+			}
+			return dataVector;
 		}
 
 		std::size_t getDataLength() {

--- a/src/tcp/TcpClient.cpp
+++ b/src/tcp/TcpClient.cpp
@@ -136,7 +136,7 @@ void TcpClient::handle_connect(const asio::error_code& ec,
 	// Otherwise we have successfully established a connection.
 	else
 	{
-		std::printf("ofxAsio::sockets::TcpClient -- Connected to %s\n", endpoint_iter->endpoint());
+		std::printf("ofxAsio::sockets::TcpClient -- Connected to %s:%d\n", endpoint_iter->endpoint().address().to_string().c_str(), endpoint_iter->endpoint().port());
 
 		// Start the input actor.
 		start_read();
@@ -170,7 +170,7 @@ void TcpClient::handle_read(const asio::error_code& ec, size_t bytes_received) {
 		// Empty messages are heartbeats and so ignored.
 		if (!line.empty())
 		{
-			std::printf("Received: %s\n");
+			std::printf("Received: %s\n", line.c_str());
 		}
 
 		start_read();

--- a/src/tcp/TcpSession.cpp
+++ b/src/tcp/TcpSession.cpp
@@ -48,9 +48,9 @@ void TcpSession::onWrite(const asio::error_code& error, std::size_t bytesReceive
 
 void TcpSession::onReceive(const asio::error_code& error, std::size_t bytesReceived) {
 	if (bytesReceived) {
-		std::printf("ofxAsio::sockets::TcpSession::onReceive -- received message %s in %d bytes\n", mIncomingMessage.c_str(), bytesReceived);
+		std::printf("ofxAsio::sockets::TcpSession::onReceive -- received message %s in %lu bytes\n", mIncomingMessage.c_str(), bytesReceived);
 		if (mIncomingMessage[bytesReceived - 1] == mTerminator) {
-			std::printf("ofxAsio::sockets::TcpSession::onReceive -- received terminator charactder %s\n", mTerminator);
+			std::printf("ofxAsio::sockets::TcpSession::onReceive -- received terminator character %c\n", mTerminator);
 			--bytesReceived;
 			setIncomingBufferSize(bytesReceived);
 			mIsConnected = false;


### PR DESCRIPTION
Minor changes to make ofxAsio compile on Mojave.
Clang doesn't allow reinterpret_cast from char to unsigned char.